### PR TITLE
Fix card-hanging for suggestion swiping

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,8 @@
   "devDependencies": {
     "ionic": "driftyco/ionic-bower#1.1.1",
     "ionic-ion-tinder-cards": "ionic-contrib-tinder-cards#*"
+  },
+  "resolutions": {
+    "collide": "1.0.0-beta.3"
   }
 }

--- a/www/index.html
+++ b/www/index.html
@@ -17,6 +17,8 @@
     <link href="css/ionic.app.css" rel="stylesheet">
     -->
 
+    <script src="lib/collide/collide.js"></script>
+
     <!-- ionic/angularjs js -->
     <script src="lib/ionic/js/ionic.bundle.js"></script>
     <script src="lib/ionic-ion-tinder-cards/ionic.tdcards.js"></script>


### PR DESCRIPTION
@cclark07 @kbaek FYI you will need to do a `bower install` when this gets merged in.
- Adds collide.js library (a dependency for tinder-cards lib)
